### PR TITLE
fix(framework): FunctionInvoker sets the request path

### DIFF
--- a/framework/core/invoker.go
+++ b/framework/core/invoker.go
@@ -91,6 +91,8 @@ func (fn *FunctionInvoker) StreamRequest(reqBody CoreRuntimeRequest) (*http.Requ
 		return nil, err
 	}
 
+	request.URL.Path = event.Path
+
 	for key, values := range event.Headers {
 		request.Header.Set(key, values)
 	}

--- a/framework/core/invoker_test.go
+++ b/framework/core/invoker_test.go
@@ -58,7 +58,7 @@ func TestExecutePath(t *testing.T) {
 	t.Parallel()
 
 	const path = "/test/path"
-	original, err := http.NewRequest(http.MethodGet, path, http.NoBody)
+	original, err := http.NewRequestWithContext(context.Background(), http.MethodGet, path, http.NoBody)
 	require.NoError(t, err)
 	assert.Equal(t, path, original.URL.Path)
 

--- a/framework/core/invoker_test.go
+++ b/framework/core/invoker_test.go
@@ -58,7 +58,7 @@ func TestExecutePath(t *testing.T) {
 	t.Parallel()
 
 	const path = "/test/path"
-	original, err := http.NewRequest(http.MethodGet, path, nil)
+	original, err := http.NewRequest(http.MethodGet, path, http.NoBody)
 	require.NoError(t, err)
 	assert.Equal(t, path, original.URL.Path)
 

--- a/framework/core/invoker_test.go
+++ b/framework/core/invoker_test.go
@@ -54,6 +54,25 @@ func TestStreamRequestUserAgent(t *testing.T) {
 	assert.NotNil(t, invoker)
 }
 
+func TestExecutePath(t *testing.T) {
+	t.Parallel()
+
+	const path = "/test/path"
+	original, err := http.NewRequest(http.MethodGet, path, nil)
+	require.NoError(t, err)
+	assert.Equal(t, path, original.URL.Path)
+
+	invoker, err := NewInvoker("", "", "", "", "", false)
+	require.NoError(t, err)
+	assert.NotNil(t, invoker)
+
+	event := FormatEventHTTP(original, nil)
+	req, err := invoker.Execute(event, GetExecutionContext(), TriggerTypeHTTP)
+	require.NoError(t, err)
+	assert.NotNil(t, req)
+	assert.Equal(t, original.URL.Path, req.URL.Path)
+}
+
 func TestStreamExecute(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
## Summary

**_What's changed?_**
The `FunctionInvoker` will now construct a request with a path that matches the one of the incoming event.
**_Why do we need this?_**
As of now both local and production function handlers receive an empty path even if the original HTTP request has it. The path is effectively being erased making it hard to reuse standard golang code that needs path-based routing.
**_How have you tested it?_**
Wrote a unit test and tested it locally in `examples/handler` by pointing the framework dependency to a local directory.
## Checklist

- [x] I have reviewed this myself
- [x] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation