### PR TITLE
Remove TriggerType (only HTTP) and use APIGatewayProxyRequest type for Event

### DIFF
--- a/framework/core/events.go
+++ b/framework/core/events.go
@@ -7,14 +7,6 @@ import (
 )
 
 var (
-	// TriggerTypeHTTP Event trigger of type HTTP.
-	TriggerTypeHTTP TriggerType = "http"
-
-	// ValidTriggerTypes List of supported trigger types.
-	ValidTriggerTypes = []TriggerType{TriggerTypeHTTP}
-)
-
-var (
 	// ErrNotSupportedTrigger Error when event is assigned to not supported trigger types.
 	ErrNotSupportedTrigger = errors.New("trigger Type is not supported by Scaleway Functions Runtime")
 
@@ -22,36 +14,13 @@ var (
 	ErrReadBody = errors.New("unable to read request body")
 )
 
-// TriggerType Enumeration of valid trigger types supported by runtime.
-type TriggerType string
-
-// GetTriggerType check that a given trigger type is supported by runtime.
-func GetTriggerType(triggerType string) (TriggerType, error) {
-	if triggerType == "" {
-		return TriggerTypeHTTP, nil
-	}
-
-	for _, validType := range ValidTriggerTypes {
-		if string(validType) == triggerType {
-			return validType, nil
-		}
-	}
-
-	return "", ErrNotSupportedTrigger
-}
-
-// FormatEvent Format event according to given trigger type, if trigger type if not HTTP, then we assume that event
-// has already been formatted by event-source.
-func FormatEvent(req *http.Request, triggerType TriggerType) (interface{}, error) {
+// FormatEvent Format event
+func FormatEvent(req *http.Request) (APIGatewayProxyRequest, error) {
 	// request body is the event
 	bodyBytes, err := io.ReadAll(req.Body)
 	if err != nil {
-		return nil, ErrReadBody
+		return APIGatewayProxyRequest{}, ErrReadBody
 	}
 
-	if triggerType == TriggerTypeHTTP {
-		return FormatEventHTTP(req, bodyBytes), nil
-	}
-
-	return string(bodyBytes), nil
+	return FormatEventHTTP(req, bodyBytes), nil
 }

--- a/framework/core/events_test.go
+++ b/framework/core/events_test.go
@@ -11,30 +11,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestGetTriggerDefault(t *testing.T) {
-	t.Parallel()
-
-	tt, err := GetTriggerType("")
-	require.NoError(t, err)
-	assert.Equal(t, TriggerTypeHTTP, tt)
-}
-
-func TestGetTriggerInvalid(t *testing.T) {
-	t.Parallel()
-
-	tt, err := GetTriggerType("invalid")
-	assert.Error(t, ErrNotSupportedTrigger, err)
-	assert.Equal(t, TriggerType(""), tt)
-}
-
-func TestGetTriggerValidHTTP(t *testing.T) {
-	t.Parallel()
-
-	tt, err := GetTriggerType(string(TriggerTypeHTTP))
-	require.NoError(t, err)
-	assert.Equal(t, TriggerTypeHTTP, tt)
-}
-
 func TestFormatEventGood(t *testing.T) {
 	t.Parallel()
 
@@ -57,23 +33,17 @@ func TestFormatEventGood(t *testing.T) {
 		URL:    &testURL,
 	}
 
-	formattedEvent, err := FormatEvent(&req, TriggerTypeHTTP)
+	formattedEvent, err := FormatEvent(&req)
 
 	require.NoError(t, err)
 	assert.NotNil(t, formattedEvent)
 
-	// try cast event
-
-	castedEvt, castSucceeds := formattedEvent.(APIGatewayProxyRequest)
-	require.True(t, castSucceeds)
-	assert.NotNil(t, castedEvt)
-
-	assert.Equal(t, testBody, castedEvt.Body)
-	assert.Equal(t, testURLPath, castedEvt.Path)
-	assert.Equal(t, http.MethodPatch, castedEvt.HTTPMethod)
-	assert.Equal(t, http.MethodPatch, castedEvt.RequestContext.HTTPMethod)
+	assert.Equal(t, testBody, formattedEvent.Body)
+	assert.Equal(t, testURLPath, formattedEvent.Path)
+	assert.Equal(t, http.MethodPatch, formattedEvent.HTTPMethod)
+	assert.Equal(t, http.MethodPatch, formattedEvent.RequestContext.HTTPMethod)
 
 	// headers are flattened so expected result changed
-	assert.Equal(t, map[string]string{"multi": "val1,val2"}, castedEvt.Headers)
-	assert.False(t, castedEvt.IsBase64Encoded)
+	assert.Equal(t, map[string]string{"multi": "val1,val2"}, formattedEvent.Headers)
+	assert.False(t, formattedEvent.IsBase64Encoded)
 }

--- a/framework/core/invoker.go
+++ b/framework/core/invoker.go
@@ -53,6 +53,8 @@ func NewInvoker(
 }
 
 // Execute a given function handler, and handle response.
+//
+//nolint:gocritic
 func (fn *FunctionInvoker) Execute(event APIGatewayProxyRequest, ctx ExecutionContext) (*http.Request, error) {
 	reqBody := CoreRuntimeRequest{
 		Event:       event,

--- a/framework/core/invoker_test.go
+++ b/framework/core/invoker_test.go
@@ -67,7 +67,7 @@ func TestExecutePath(t *testing.T) {
 	assert.NotNil(t, invoker)
 
 	event := FormatEventHTTP(original, nil)
-	req, err := invoker.Execute(event, GetExecutionContext(), TriggerTypeHTTP)
+	req, err := invoker.Execute(event, GetExecutionContext())
 	require.NoError(t, err)
 	assert.NotNil(t, req)
 	assert.Equal(t, original.URL.Path, req.URL.Path)
@@ -102,11 +102,11 @@ func TestStreamExecute(t *testing.T) {
 	httpreq, err := http.NewRequestWithContext(context.Background(), http.MethodPost, server.URL, stringReadCloser)
 	require.NoError(t, err)
 
-	event, err := FormatEvent(httpreq, TriggerTypeHTTP)
+	event, err := FormatEvent(httpreq)
 	require.NoError(t, err)
 	assert.NotNil(t, event)
 
-	resp, err := invoker.Execute(event, GetExecutionContext(), TriggerTypeHTTP)
+	resp, err := invoker.Execute(event, GetExecutionContext())
 	require.NoError(t, err)
 	assert.NotNil(t, resp)
 }

--- a/local/core.go
+++ b/local/core.go
@@ -37,7 +37,7 @@ func CoreProcessing(httpResp http.ResponseWriter, httpReq *http.Request, handler
 
 	invoker := core.FunctionInvoker{}
 
-	reqForFaaS, err := invoker.Execute(formattedRequest, core.GetExecutionContext(), core.TriggerTypeHTTP)
+	reqForFaaS, err := invoker.Execute(formattedRequest, core.GetExecutionContext())
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
## Summary

**_What's changed?_**

- remove references to `TriggerType`
- change `Event` type from `interface{}` to `APIGatewayProxyRequest`
 
**_Why do we need this?_**

- `TriggerType` is always used as `TriggerHTTP`, so this simplifies the code
- before, `Event` type could differ if `TriggerType` was not `TriggerHTTP`, so to encapsulate all possible cases, an `interface{}` was used. Now that `TriggerHTTP` is removed, we can strongly type `Event` with `APIGatewayProxyRequest` type

**_How have you tested it?_**

Unit tests.

## Checklist

- [X] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation