### PR TITLE
Use application/json content-type between core and sub runtimes

### DIFF
--- a/framework/core/invoker.go
+++ b/framework/core/invoker.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"strings"
 )
 
 // CoreRuntimeRequest - Structure for a request from core runtime to sub-runtime with event,
@@ -84,7 +85,14 @@ func (fn *FunctionInvoker) StreamRequest(reqBody CoreRuntimeRequest) (*http.Requ
 
 	request.URL.Path = event.Path
 
+	// When sending the request to the sub runtime, the request is always in JSON format.
+	request.Header.Set(contentTypeHeaderKey, "application/json")
+
 	for key, values := range event.Headers {
+		if strings.EqualFold(key, contentTypeHeaderKey) {
+			continue
+		}
+
 		request.Header.Set(key, values)
 	}
 
@@ -92,10 +100,6 @@ func (fn *FunctionInvoker) StreamRequest(reqBody CoreRuntimeRequest) (*http.Requ
 		for idx := range values {
 			request.Header.Add(key, values[idx])
 		}
-	}
-
-	if request.Header.Get(contentTypeHeaderKey) == "" {
-		request.Header.Set(contentTypeHeaderKey, "application/json")
 	}
 
 	if event.Headers[userAgentHeaderKey] != "" {


### PR DESCRIPTION
## Summary

**_What's changed?_**

Requests between the core runtime and sub runtimes are now defining a `Content-Type=application/json` header.
 
**_Why do we need this?_**

Before, the `Content-Type` header used by the client (e.g. `application/octet-stream`) was also used in the request between core runtime and sub runtime. This was incorrect, since the client call (headers, body, method, etc.) is **always** wrapped in JSON.

**_How have you tested it?_**

With node20 runtime:

- before: `curl -H "Content-Type: application/octet-stream"` was sending an error because `application/octet-stream` content type was not handled
- now: no error

Run all function runtimes IT tests.

## Checklist

- [X] I have reviewed this myself
- [ ] There is a unit test covering every change in this PR
- [ ] I have updated the relevant documentation